### PR TITLE
[fix] internal method wrapping error

### DIFF
--- a/kinesis/runner.go
+++ b/kinesis/runner.go
@@ -245,7 +245,7 @@ func (r *runner) processRecord(record *kinesis.Record) (err error) {
 	message := Message{ShardID: r.shardID, PartitionKey: aws.StringValue(record.PartitionKey), Data: record.Data}
 
 	if err := r.handler(context.Background(), message); err != nil {
-		return errors.Wrap(err, "error handling message")
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
- internal method wrapping prevents other errors from showing up properly
  even if they implement a %v formatter.